### PR TITLE
feat: add command_manager role for command management

### DIFF
--- a/libs/@helpasaur/types/src/api.ts
+++ b/libs/@helpasaur/types/src/api.ts
@@ -6,6 +6,25 @@
 // User Types
 import { TwitchPrivilegedUserData, TwitchUserData } from "twitch-api-client"
 
+// Permission Types
+export enum Permission {
+  ADMIN = "admin",
+  SERVICE = "service",
+  COMMAND_MANAGER = "command_manager",
+}
+
+export const hasAnyPermission = (
+  userPermissions: string[],
+  requiredPermissions: Permission[]
+): boolean => {
+  return requiredPermissions.some((p) => userPermissions.includes(p))
+}
+
+export const COMMAND_EDIT_PERMISSIONS: Permission[] = [
+  Permission.ADMIN,
+  Permission.COMMAND_MANAGER,
+]
+
 export enum ApiResult {
   SUCCESS = "success",
   ERROR = "error",

--- a/web/src/pages/CommandsPage.tsx
+++ b/web/src/pages/CommandsPage.tsx
@@ -4,6 +4,7 @@ import { Alert, Container, Spinner } from "react-bootstrap"
 import CommandsList from "../components/CommandsList"
 import { sortCommandsAlpha } from "../utils"
 import { useHelpaApi } from "../hooks/useHelpaApi"
+import { hasAnyPermission, COMMAND_EDIT_PERMISSIONS } from "@helpasaur/types"
 
 interface CommandsPageProps {}
 
@@ -52,7 +53,11 @@ const CommandsPage: React.FunctionComponent<CommandsPageProps> = () => {
       {!commandsError && !commandsLoading && (
         <CommandsList
           commands={sortCommandsAlpha(commands || [])}
-          userCanEdit={user ? user.permissions.includes("admin") : false}
+          userCanEdit={
+            user
+              ? hasAnyPermission(user.permissions, COMMAND_EDIT_PERMISSIONS)
+              : false
+          }
           createCommandMutation={createCommandMutation}
           updateCommandMutation={updateCommandMutation}
           deleteCommandMutation={deleteCommandMutation}


### PR DESCRIPTION
## Summary
- Adds a `command_manager` permission that grants users CRUD access to commands without requiring full `admin` privileges
- Introduces `Permission` enum, `hasAnyPermission` helper, and `COMMAND_EDIT_PERMISSIONS` constant in `@helpasaur/types`
- Updates API route guards on POST/PATCH/DELETE `/commands` to accept either `admin` or `command_manager`
- Updates `CommandsPage` frontend to use the shared permission check

## Test plan
- [x] Verify admin users can still create, update, and delete commands
- [x] Verify users with `command_manager` permission can create, update, and delete commands
- [x] Verify users without either permission cannot modify commands
- [x] Verify read-only command endpoints remain publicly accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)