### PR TITLE
feat: validate command response length against Twitch 500-char limit

### DIFF
--- a/api/src/models/command.ts
+++ b/api/src/models/command.ts
@@ -1,10 +1,16 @@
 import mongoose, { Schema } from "mongoose"
 import { ICommandDocument, ICommandModel } from "../types/models"
+import { TWITCH_MAX_MESSAGE_LENGTH } from "@helpasaur/common"
 
 const CommandSchema = new Schema<ICommandDocument>({
   command: { type: String, required: true, trim: true },
   aliases: [String],
-  response: { type: String, required: true, trim: true },
+  response: {
+    type: String,
+    required: true,
+    trim: true,
+    maxlength: TWITCH_MAX_MESSAGE_LENGTH,
+  },
   category: String,
   tags: [String],
   enabled: Boolean,

--- a/api/src/routes/api/commands.ts
+++ b/api/src/routes/api/commands.ts
@@ -8,7 +8,7 @@ import {
   handleRouteError,
 } from "../../lib/responseHelpers"
 import guard from "express-jwt-permissions"
-import { normalizeTags } from "@helpasaur/common"
+import { normalizeTags, TWITCH_MAX_MESSAGE_LENGTH } from "@helpasaur/common"
 
 interface MatchFilter {
   createdAt?: {
@@ -170,6 +170,13 @@ router.post(
       if (!req.body.response || !req.body.response.trim()) {
         return sendError(res, "Command response is required", 400)
       }
+      if (req.body.response.length > TWITCH_MAX_MESSAGE_LENGTH) {
+        return sendError(
+          res,
+          `Command response must be ${TWITCH_MAX_MESSAGE_LENGTH} characters or less (Twitch limit)`,
+          400
+        )
+      }
 
       // Ensure command name and alias uniqueness
       const isUnique = await Command.isUnique(
@@ -251,6 +258,16 @@ router.patch(
         (!req.body.response || !req.body.response.trim())
       ) {
         return sendError(res, "Command response is required", 400)
+      }
+      if (
+        req.body.response &&
+        req.body.response.length > TWITCH_MAX_MESSAGE_LENGTH
+      ) {
+        return sendError(
+          res,
+          `Command response must be ${TWITCH_MAX_MESSAGE_LENGTH} characters or less (Twitch limit)`,
+          400
+        )
       }
 
       // Store original tags for comparison

--- a/libs/@helpasaur/common/src/constants.ts
+++ b/libs/@helpasaur/common/src/constants.ts
@@ -1,0 +1,2 @@
+// Twitch enforces a maximum of 500 characters per chat message
+export const TWITCH_MAX_MESSAGE_LENGTH = 500

--- a/libs/@helpasaur/common/src/index.ts
+++ b/libs/@helpasaur/common/src/index.ts
@@ -4,4 +4,5 @@
  */
 
 export * from "./command-cache"
+export * from "./constants"
 export * from "./utils/tagUtils"

--- a/web/src/components/CommandFormModal.tsx
+++ b/web/src/components/CommandFormModal.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { Button, FloatingLabel, Form, Modal } from "react-bootstrap"
 import { Command } from "@helpasaur/types"
+import { TWITCH_MAX_MESSAGE_LENGTH } from "@helpasaur/common"
 import { useHelpaApi } from "../hooks/useHelpaApi"
 import TagInput from "./TagInput"
 import AliasInput from "./AliasInput"
@@ -56,6 +57,9 @@ const CommandFormModal: React.FunctionComponent<CommandFormModalProps> = (
     }))
   }
 
+  const responseLength = (command.response || "").length
+  const isOverLimit = responseLength > TWITCH_MAX_MESSAGE_LENGTH
+
   const handleSubmit = () => {
     onSubmit(command)
   }
@@ -93,7 +97,11 @@ const CommandFormModal: React.FunctionComponent<CommandFormModalProps> = (
             name="response"
             value={command.response || ""}
             onChange={handleChange}
+            isInvalid={isOverLimit}
           />
+          <Form.Text className={isOverLimit ? "text-danger" : "text-muted"}>
+            {responseLength}/{TWITCH_MAX_MESSAGE_LENGTH}
+          </Form.Text>
         </FloatingLabel>
 
         {/* Aliases Input with Badge UI */}
@@ -119,7 +127,7 @@ const CommandFormModal: React.FunctionComponent<CommandFormModalProps> = (
         <Button variant="primary" onClick={onHide}>
           Cancel
         </Button>
-        <Button variant="dark" onClick={handleSubmit}>
+        <Button variant="dark" onClick={handleSubmit} disabled={isOverLimit}>
           <i className="fa-regular fa-floppy-disk px-1"></i> Save Changes
         </Button>
       </Modal.Footer>


### PR DESCRIPTION
## Summary
- Adds `TWITCH_MAX_MESSAGE_LENGTH` (500) constant in `@helpasaur/common` shared across API and web
- Enforces response length validation on API `POST /commands` and `PATCH /commands/:id` routes, returning a 400 error when exceeded
- Adds `maxlength` constraint to the Mongoose Command schema as defense-in-depth
- Adds a live character counter (`current/500`) to the command form modal, with red styling and disabled save button when over the limit

## Test plan
- [x] `pnpm typecheck` passes across all 12 packages
- [x] `pnpm lint:check` passes with zero warnings
- [x] API tested live: POST with 501 chars → 400 error, POST with 500 chars → 201 created
- [x] API tested live: PATCH with 501 chars → 400 error, PATCH with valid response → 200 updated
- [ ] Verify character counter and save button behavior in web UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)